### PR TITLE
com.apple.developer.associated-domainsの値を変数から実際の値に変更

### DIFF
--- a/Covid19Radar/Covid19Radar.iOS/Entitlements.plist
+++ b/Covid19Radar/Covid19Radar.iOS/Entitlements.plist
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:APPLINKS_DOMAIN</string>
+		<string>applinks:www.mhlw.go.jp</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
このレビューコメントでiOSのみ変数を使うことにしましたが、改めて考えてみるとiOS, Androidで違うのは逆に混乱するかなと思ったため、Android同様に直接値を入れる形にしました。
https://github.com/cocoa-mhlw/cocoa/pull/454